### PR TITLE
Add useful metrics

### DIFF
--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         - -health-probe-bind-address=:8081
         - -config=/etc/etcd-shield/config.yaml
         - -port=8443
+        - -metrics-addr=:9100
         env:
         - name: "NAMESPACE"
           valueFrom:

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -19,3 +19,4 @@ resources:
 - service.yaml
 - webhook.yaml
 - prometheus.etcd_shield_alerts.yaml
+- ./metrics

--- a/config/metrics/kustomization.yaml
+++ b/config/metrics/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- monitor.yaml
+- service-account.yaml
+- rbac.yaml
+- network_policy.yaml
+- metrics-service.yaml

--- a/config/metrics/metrics-service.yaml
+++ b/config/metrics/metrics-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd-shield-metrics
+  namespace: etcd-shield
+spec:
+  selector:
+    app: etcd-shield
+  type: ClusterIP
+  ports:
+  - name: metrics
+    targetPort: 9100
+    port: 9100

--- a/config/metrics/monitor.yaml
+++ b/config/metrics/monitor.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: etcd-shield-metrics
+  labels:
+    apps: etcd-shield
+spec:
+  endpoints:
+    - interval: 15s
+      scheme: https
+      path: /metrics
+      port: metrics
+      authorization:
+        credentials:
+          key: token
+          name: metrics-reader
+      tlsConfig:
+        ca:
+          secret:
+            key: service-ca.crt
+            name: metrics-reader
+            optional: false
+        serverName: etcd-shield.etcd-shield.svc
+  selector:
+    matchLabels:
+      apps: etcd-shield

--- a/config/metrics/network_policy.yaml
+++ b/config/metrics/network_policy.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-user-workload-monitoring
+  namespace: etcd-shield
+spec:
+  podSelector:
+    matchLabels:
+      apps: etcd-shield
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-user-workload-monitoring
+    ports:
+    - protocol: TCP
+      port: metrics

--- a/config/metrics/rbac.yaml
+++ b/config/metrics/rbac.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-shield-metrics
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-etcd-shield-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-shield-metrics
+subjects:
+- kind: ServiceAccount
+  name: metrics-reader
+  namespace: etcd-shield

--- a/config/metrics/service-account.yaml
+++ b/config/metrics/service-account.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: metrics-reader
+  name: metrics-reader
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-reader
+  namespace: etcd-shield

--- a/config/rbac.yaml
+++ b/config/rbac.yaml
@@ -19,6 +19,18 @@ roleRef:
   name: etcd-shield-authorizer
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-shield-authorizer
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["subjectaccessreviews"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: etcd-shield

--- a/pkg/metrics.go
+++ b/pkg/metrics.go
@@ -1,0 +1,44 @@
+// Copyright 2025 Red Hat Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcd_shield
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type Metrics struct {
+	Enabled prometheus.Gauge
+}
+
+var _ prometheus.Collector = &Metrics{}
+
+// Collect implements prometheus.Collector.
+func (m *Metrics) Collect(channel chan<- prometheus.Metric) {
+	m.Enabled.Collect(channel)
+}
+
+// Describe implements prometheus.Collector.
+func (m *Metrics) Describe(channel chan<- *prometheus.Desc) {
+	m.Enabled.Describe(channel)
+}
+
+func NewMetrics() *Metrics {
+	return &Metrics{
+		Enabled: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "etcd_shield",
+			Subsystem: "alert",
+			Name:      "triggered",
+			Help:      "Current state of etcd-shield, as observed by etcd-shield itself.  0 implies allowing, 1 implies denying.",
+		}),
+	}
+}

--- a/pkg/querier.go
+++ b/pkg/querier.go
@@ -26,13 +26,15 @@ type Querier struct {
 	state      StateManager
 	prometheus PromQuery
 	config     Config
+	metrics    *Metrics
 }
 
-func NewQuerier(prom PromQuery, state StateManager, config Config) *Querier {
+func NewQuerier(prom PromQuery, state StateManager, config Config, metrics *Metrics) *Querier {
 	querier := Querier{
 		prometheus: prom,
 		state:      state,
 		config:     config,
+		metrics:    metrics,
 	}
 
 	return &querier
@@ -76,6 +78,13 @@ func (q *Querier) Process(ctx context.Context) error {
 	err = q.state.WriteConfig(ctx, !firing)
 	if err != nil {
 		return err
+	}
+
+	// step 3: write metrics
+	if firing {
+		q.metrics.Enabled.Set(1.0)
+	} else {
+		q.metrics.Enabled.Set(0.0)
 	}
 
 	return nil

--- a/pkg/webhook.go
+++ b/pkg/webhook.go
@@ -23,12 +23,14 @@ import (
 )
 
 type Webhook struct {
-	state StateManager
+	state   StateManager
+	metrics *Metrics
 }
 
-func NewWebhook(state StateManager) admission.CustomValidator {
+func NewWebhook(state StateManager, metrics *Metrics) admission.CustomValidator {
 	return &Webhook{
-		state: state,
+		state:   state,
+		metrics: metrics,
 	}
 }
 


### PR DESCRIPTION
`etcd-shield` should serve a new metric, which might help us better understand its usage patterns:

- `etcd_shield_query_enabled`: What does `etcd-shield` think the current admission state is?