### PR TITLE
Add in-memory state manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	k8s.io/api v0.31.7
 	k8s.io/apimachinery v0.31.7
 	k8s.io/client-go v0.31.7
+	pgregory.net/rapid v1.2.0
 	sigs.k8s.io/controller-runtime v0.19.7
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -728,6 +728,8 @@ k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 h1:pUdcCO1Lk/tbT5ztQWOBi5HBgbBP1
 k8s.io/utils v0.0.0-20240711033017-18e509b52bc8/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 knative.dev/pkg v0.0.0-20240416145024-0f34a8815650 h1:m2ahFUO0L2VrgGDYdyOUFdE6xBd3pLXAJozLJwqLRQM=
 knative.dev/pkg v0.0.0-20240416145024-0f34a8815650/go.mod h1:soFw5ss08G4PU3JiFDKqiZRd2U7xoqcfNpJP1coIXkY=
+pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
+pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/in_memory_state.go
+++ b/pkg/in_memory_state.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Red Hat Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcd_shield
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+type InMemoryState struct {
+	state atomic.Bool
+}
+
+func NewInMemoryState() StateManager {
+	return &InMemoryState{
+		state: atomic.Bool{},
+	}
+}
+
+var _ StateManager = &InMemoryState{}
+
+// ReadConfig implements StateManager.
+func (a *InMemoryState) ReadConfig(context.Context) (bool, error) {
+	return a.state.Load(), nil
+}
+
+// WriteConfig implements StateManager.
+func (a *InMemoryState) WriteConfig(_ context.Context, state bool) error {
+	a.state.Store(state)
+	return nil
+}

--- a/pkg/in_memory_state_test.go
+++ b/pkg/in_memory_state_test.go
@@ -1,0 +1,69 @@
+// Copyright 2025 Red Hat Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcd_shield_test
+
+import (
+	"context"
+
+	etcd_shield "github.com/konflux-ci/etcd-shield/pkg"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"pgregory.net/rapid"
+)
+
+var _ = Describe("in-memory smoke tests", func() {
+	var state etcd_shield.StateManager
+
+	BeforeEach(func() {
+		state = etcd_shield.NewInMemoryState()
+	})
+
+	It("should return the value written", func(ctx context.Context) {
+		rapid.Check(GinkgoT(), func(t *rapid.T) {
+			g := NewWithT(t)
+
+			for range 100 {
+				s := rapid.Bool().Draw(t, "state")
+
+				g.Expect(state.WriteConfig(ctx, s)).To(Succeed())
+				g.Expect(state.ReadConfig(ctx)).To(Equal(s))
+			}
+		})
+	})
+
+	It("should not return errors on reads", func(ctx context.Context) {
+		rapid.Check(GinkgoT(), func(t *rapid.T) {
+			g := NewWithT(t)
+			s := rapid.Bool().Draw(t, "state")
+
+			g.Expect(state.WriteConfig(ctx, s)).To(Succeed())
+
+			for range 100 {
+				g.Expect(state.ReadConfig(ctx)).To(Equal(s))
+			}
+		})
+	})
+
+	It("should not return errors on writes", func(ctx context.Context) {
+		rapid.Check(GinkgoT(), func(t *rapid.T) {
+			g := NewWithT(t)
+			s := rapid.Bool().Draw(t, "state")
+
+			for range 100 {
+				g.Expect(state.WriteConfig(ctx, s)).To(Succeed())
+			}
+		})
+	})
+})


### PR DESCRIPTION
Add a new state manager that communicates the current alerting state as a shared in-memory state, rather than through a configmap stored in-cluster.  Consistency between threads is ensured through atomics, as the extra semantics enforced through other synchronization primitives is unnecessary here.

This is feature gated behind an environment variable (`STATE_MANAGER`).  Setting it to `in-memory` uses this new manager, while any other value uses the old in-cluster manager.