### PR TITLE
Configure Renovate for weekly schedule with release age filter

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "schedule": ["before 7am on Monday"],
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "matchManagers": [


### PR DESCRIPTION
Change Renovate to run once a week (Monday morning) and require releases to be at least 3 days old before proposing them. This reduces PR noise and avoids picking up broken releases that get yanked shortly after publishing.

Contributes to: KFLUXINFRA-3008