### PR TITLE
run e2e tests on push on main

### DIFF
--- a/.github/workflows/chainsaw-tests.yaml
+++ b/.github/workflows/chainsaw-tests.yaml
@@ -3,6 +3,8 @@ name: Run Chainsaw tests
 on:
   pull_request:
     branches: [ main ]
+  push:
+    branches: [main]
 
 jobs:
   chainsaw-test:


### PR DESCRIPTION
It's nice to validate that merged changes are passing once in main.

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED
