### PR TITLE
Add dependency PR triage workflow

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,27 @@
+name: Auto-merge approved dependency PRs
+
+on:
+  check_suite:
+    types: [completed]
+
+jobs:
+  auto-merge:
+    name: Merge if all checks pass
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
+      statuses: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.KONFLUX_INFRA_AUTO_MERGER_APP_ID }}
+          private-key: ${{ secrets.KONFLUX_INFRA_AUTO_MERGER_APP_PRIVATE_KEY }}
+      - uses: konflux-ci/deptriage@main
+        with:
+          command: merge
+          head-sha: ${{ github.event.check_suite.head_sha }}
+          github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/dep-triage.yaml
+++ b/.github/workflows/dep-triage.yaml
@@ -1,0 +1,33 @@
+name: Dependency Impact Analysis
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+concurrency:
+  group: dep-triage-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    name: Triage dependency PR
+    if: >-
+      github.event.pull_request.user.login == 'renovate[bot]' ||
+      github.event.pull_request.user.login == 'red-hat-konflux[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      checks: read
+      statuses: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: konflux-ci/deptriage@main
+        with:
+          command: both
+          pr-number: ${{ github.event.pull_request.number }}
+          api-key: ${{ secrets.GEMINI_API_KEY }}
+          llm-provider: gemini
+          auto-approve: 'true'
+          auto-merge: 'true'


### PR DESCRIPTION
Integrate the deptriage action (konflux-ci/deptriage) to automate dependency PR review for bot-generated PRs from Renovate and red-hat-konflux[bot].

Two workflows are added:
- dep-triage.yaml: triggers on PR open/sync, classifies the semver bump type, detects risk patterns (e.g., Go toolchain changes), and runs AI-assisted impact analysis via Gemini. Eligible low-risk patches are  auto-approved with labels and a formal APPROVE review.
- auto-merge.yaml: triggers on check_suite completion, merges PRs that have approved/lgtm labels and all CI checks passing. Uses a GitHub App token (KONFLUX_INFRA_AUTO_MERGER_APP_ID) to submit an APPROVE review  before merging, satisfying the branch ruleset requirement for approval from someone other than the last pusher.