### PR TITLE
Remove minimumReleaseAge from Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "schedule": ["before 7am on Monday"],
-  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "matchManagers": [


### PR DESCRIPTION
The 3-day minimum release age was added to avoid picking up broken releases, but with the dependency PR triage workflow now in place, this filter is redundant and counterproductive — it prevents Renovate from creating PRs for recent releases, so the triage workflow never gets a chance to evaluate them. The AI-based triage provides a better assessment of merge readiness than a blanket age gate.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Contributes to: KFLUXINFRA-3320