### PR TITLE
fix: Use client-id instead of deprecated app-id for create-github-app…

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 #v3
         id: app-token
         with:
-          app-id: ${{ secrets.KONFLUX_INFRA_AUTO_MERGER_APP_ID }}
+          client-id: ${{ secrets.KONFLUX_INFRA_AUTO_MERGER_APP_ID }}
           private-key: ${{ secrets.KONFLUX_INFRA_AUTO_MERGER_APP_PRIVATE_KEY }}
       - uses: konflux-ci/deptriage@main
         with:


### PR DESCRIPTION
…-token